### PR TITLE
feat: allow validators to be objects and functions

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -112,7 +112,12 @@ export class AppComponent {
     }),
     passwords: createFormGroup({
       password: createFormField(this.reference.password.password, {
-        validators: [V.required(), V.minLength(5)],
+        validators: [V.required(), {
+          validator: V.minLength(5),
+          disable: () => this.reference.password.password().startsWith('@@'),
+          message: ({currentLength, minLength}: {currentLength: number
+            minLength: number}) => `Password must be at least ${minLength} characters long. Add at least ${minLength - currentLength} characters`
+        }],
       }),
       passwordConfirmation: createFormField(
         this.reference.password.passwordConfirmation,

--- a/src/signal-forms/validators.ts
+++ b/src/signal-forms/validators.ts
@@ -1,7 +1,7 @@
 import {Signal} from '@angular/core';
-import {SetValidationState, Validator} from './validation';
+import {SetValidationState, ValidatorFn} from './validation';
 
-export function required(): Validator {
+export function required(): ValidatorFn {
   return (value: unknown, setState: SetValidationState) => {
     const valid = value !== null && value !== undefined && value !== '';
     if (valid) {
@@ -12,7 +12,7 @@ export function required(): Validator {
   };
 }
 
-export function minLength(length: number): Validator<string | Array<unknown>> {
+export function minLength(length: number): ValidatorFn<string | Array<unknown>> {
   return (value: string | Array<unknown>, setState: SetValidationState) => {
     const valid =
       value === null || value === undefined || value.length >= length;
@@ -30,7 +30,7 @@ export function minLength(length: number): Validator<string | Array<unknown>> {
   };
 }
 
-export function equalsTo<Value>(otherValue: Signal<Value>): Validator<Value> {
+export function equalsTo<Value>(otherValue: Signal<Value>): ValidatorFn<Value> {
   return (value: Value, setState: SetValidationState) => {
     const valid = value === otherValue();
 


### PR DESCRIPTION
validators can now also be objects that have additional properties such as disable (a function that allows us to exclude a validator from execution) and message (a function that returns a custom error message)

just a prototype but maybe it's useful