### PR TITLE
feat: add debounce to signal-input.directive.ts

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,6 +9,7 @@ import {
   V,
   Validator,
   SignalInputErrorDirective,
+  SignalInputDebounceDirective,
   withErrorComponent
 } from '@signal-form';
 import { JsonPipe, NgFor, NgIf } from '@angular/common';
@@ -23,7 +24,7 @@ import {CustomErrorComponent} from "./custom-input-error.component";
         <div>
           <label>Username (tim is invalid)</label>
           <small>{{ form.controls.username.errors() | json }}</small>
-          <input ngModel [formField]="form.controls.username" />
+          <input ngModel [debounce]="700" [formField]="form.controls.username" />
         </div>
 
         <div>
@@ -90,7 +91,7 @@ import {CustomErrorComponent} from "./custom-input-error.component";
     </div>
   `,
   standalone: true,
-  imports: [JsonPipe, FormsModule, SignalInputDirective, SignalInputErrorDirective, NgIf, NgFor],
+  imports: [JsonPipe, FormsModule, SignalInputDirective, SignalInputErrorDirective, NgIf, NgFor, SignalInputDebounceDirective],
   providers: [withErrorComponent(CustomErrorComponent)]
 })
 export class AppComponent {

--- a/src/signal-forms/index.ts
+++ b/src/signal-forms/index.ts
@@ -5,5 +5,7 @@ export * from './form-group';
 export * from './signal-input.directive';
 export * from './signal-input-error.directive';
 export * from './signal-input-error.token';
+export * from './signal-input-debounce.directive';
+export * from './signal-input-modifier.token';
 
 export { V };

--- a/src/signal-forms/signal-input-debounce.directive.ts
+++ b/src/signal-forms/signal-input-debounce.directive.ts
@@ -1,0 +1,45 @@
+import {Directive, forwardRef, Input, OnDestroy} from '@angular/core';
+import {SIGNAL_INPUT_MODIFIER, SignalInputModifier} from "@signal-form/signal-input-modifier.token";
+import {debounceTime, Subject, Subscription} from "rxjs";
+
+export const DEBOUNCE_MODIFIER: any = {
+  provide: SIGNAL_INPUT_MODIFIER,
+  useExisting: forwardRef(() => SignalInputDebounceDirective),
+  multi: true
+};
+
+@Directive({
+  selector: '[ngModel][formField][debounce]',
+  standalone: true,
+  providers: [DEBOUNCE_MODIFIER]
+})
+export class SignalInputDebounceDirective implements SignalInputModifier, OnDestroy {
+  private _debounced = new Subject();
+  private _debouncedSub: Subscription | null = null;
+
+  @Input()
+  set debounce(value: number) {
+    this._debouncedSub?.unsubscribe();
+    this._debouncedSub = this._debounced.pipe(debounceTime(value))
+      .subscribe(value => {
+        this.setSignal(value)
+      })
+  }
+
+  // we replace this in the registerOnSet method with the set function passed by the SignalInputDirective
+  private setSignal(value: unknown): void {
+  }
+
+  public registerOnSet(set: (value: unknown) => void): void {
+    this.setSignal = set
+  }
+
+  public onModelChange(value: unknown): void {
+    this._debounced.next(value);
+  }
+
+  public ngOnDestroy() {
+    this._debouncedSub?.unsubscribe();
+    this._debouncedSub = null;
+  }
+}

--- a/src/signal-forms/signal-input-error.directive.ts
+++ b/src/signal-forms/signal-input-error.directive.ts
@@ -20,7 +20,7 @@ export const injectErrorField = () => inject(SIGNAL_INPUT_ERROR_FIELD);
 export class SignalInputErrorDirective implements AfterViewInit{
    private readonly viewContainerRef = inject(ViewContainerRef);
    private readonly signalInput = inject(SignalInputDirective, {optional: true});
-   private readonly component = inject(SIGNAL_INPUT_ERROR_COMPONENT)
+   private readonly component = inject(SIGNAL_INPUT_ERROR_COMPONENT);
 
   ngAfterViewInit() {
     Promise.resolve().then(() => {

--- a/src/signal-forms/signal-input-modifier.token.ts
+++ b/src/signal-forms/signal-input-modifier.token.ts
@@ -1,0 +1,9 @@
+import {InjectionToken} from "@angular/core";
+
+export interface SignalInputModifier {
+  onModelChange(value: unknown): void
+
+  registerOnSet(set: (value: unknown) => void): void;
+}
+
+export const SIGNAL_INPUT_MODIFIER = new InjectionToken<SignalInputModifier>('Custom signal input modifier');


### PR DESCRIPTION
this allows users to set a debounce-time in milliseconds. if a value is provided then the input from ngModel will be debounced for the time specified. only after it will be passed on to our signal based form field.