### PR TITLE
refactor: rework reference

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,20 +1,19 @@
-import { Component, Signal, signal } from '@angular/core';
+import { Component, SettableSignal, Signal, signal } from '@angular/core';
 import {
   createFormField,
   createFormGroup,
   FormField,
-  FormGroup,
   SetValidationState,
   SignalInputDirective,
   V,
   Validator,
   SignalInputErrorDirective,
   SignalInputDebounceDirective,
-  withErrorComponent
+  withErrorComponent,
 } from '@signal-form';
 import { JsonPipe, NgFor, NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import {CustomErrorComponent} from "./custom-input-error.component";
+import { CustomErrorComponent } from './custom-input-error.component';
 
 @Component({
   selector: 'app-root',
@@ -24,7 +23,11 @@ import {CustomErrorComponent} from "./custom-input-error.component";
         <div>
           <label>Username (tim is invalid)</label>
           <small>{{ form.controls.username.errors() | json }}</small>
-          <input ngModel [debounce]="700" [formField]="form.controls.username" />
+          <input
+            ngModel
+            [debounce]="700"
+            [formField]="form.controls.username"
+          />
         </div>
 
         <div>
@@ -91,70 +94,84 @@ import {CustomErrorComponent} from "./custom-input-error.component";
     </div>
   `,
   standalone: true,
-  imports: [JsonPipe, FormsModule, SignalInputDirective, SignalInputErrorDirective, NgIf, NgFor, SignalInputDebounceDirective],
-  providers: [withErrorComponent(CustomErrorComponent)]
+  imports: [
+    JsonPipe,
+    FormsModule,
+    SignalInputDirective,
+    SignalInputErrorDirective,
+    NgIf,
+    NgFor,
+    SignalInputDebounceDirective,
+  ],
+  providers: [withErrorComponent(CustomErrorComponent)],
 })
 export class AppComponent {
-  // TODO: this currently used to validate cross fields
-  // rework this so it's not needed or separate model and form
-  reference = {
-    password: {
-      password: signal(''),
-      passwordConfirmation: signal(''),
-    },
-    todos: signal<
-      FormGroup<{
-        description: FormField<string>;
-        completed: FormField<boolean>;
-      }>[]
-    >([]),
-  };
-
-  form = createFormGroup({
-    username: createFormField('', {
+  form = createFormGroup(() => {
+    const username = createFormField('', {
       validators: [V.required(), uniqueUsername()],
-    }),
-    passwords: createFormGroup({
-      password: createFormField(this.reference.password.password, {
-        validators: [V.required(), {
-          validator: V.minLength(5),
-          disable: () => this.reference.password.password().startsWith('@@'),
-          message: ({currentLength, minLength}: {currentLength: number
-            minLength: number}) => `Password must be at least ${minLength} characters long. Add at least ${minLength - currentLength} characters`
-        }],
-      }),
-      passwordConfirmation: createFormField(
-        this.reference.password.passwordConfirmation,
-        {
+    });
+
+    return {
+      username,
+      passwords: createFormGroup(() => {
+        const password = createFormField('', {
           validators: [
             V.required(),
-            V.equalsTo(this.reference.password.password),
+            {
+              validator: V.minLength(5),
+              disable: () =>
+                username.value().toLocaleLowerCase().startsWith('robin'),
+              message: ({
+                currentLength,
+                minLength,
+              }: {
+                currentLength: number;
+                minLength: number;
+              }) =>
+                `Password must be at least ${minLength} characters long. Add at least ${
+                  minLength - currentLength
+                } characters`,
+            },
           ],
-          hidden: () => this.reference.password.password() === '',
+        });
+
+        return {
+          password,
+          passwordConfirmation: createFormField<string | undefined>(undefined, {
+            validators: [V.required(), V.equalsTo(password.value)],
+            hidden: () => password.value() === '',
+          }),
+        };
+      }),
+      todos: createFormGroup<SettableSignal<Todo[]>>(
+        () => {
+          return signal([]);
+        },
+        {
+          validators: [V.minLength(1)],
         }
       ),
-    }),
-    todos: createFormGroup(this.reference.todos, {
-      validators: [V.minLength(1)],
-    }),
+    };
   });
 
   createTodo = () => {
-    return createFormGroup({
-      description: createFormField('', {
-        validators: [
-          V.required(),
-          V.minLength(5),
-          todoUniqueInList(this.reference.todos),
-        ],
-      }),
-      completed: createFormField(false),
+    return createFormGroup<Todo>(() => {
+      return {
+        description: createFormField('', {
+          validators: [
+            V.required(),
+            V.minLength(5),
+            todoUniqueInList(this.form.controls.todos.value as any),
+          ],
+        }),
+        completed: createFormField(false),
+      };
     });
   };
 
   addTodo() {
     this.form.controls.todos.controls.mutate((todos) =>
-      todos.push(this.createTodo())
+      (todos as any).push(this.createTodo())
     );
   }
 }
@@ -169,7 +186,7 @@ function uniqueUsername<Value>(): Validator<Value> {
       } else {
         setState('INVALID', {
           uniqueUsername: {
-            details: false
+            details: false,
           },
         });
       }
@@ -177,23 +194,28 @@ function uniqueUsername<Value>(): Validator<Value> {
   };
 }
 
-function todoUniqueInList<Value>(allTodos: Signal<any[]>): Validator<Value> {
+function todoUniqueInList<Value>(allTodos: Signal<Todo[]>): Validator<Value> {
   return (value: Value, setState: SetValidationState) => {
     if (value === '' || value === null) {
       setState('VALID');
       return;
     }
+
     const valid =
-      allTodos().filter((todo) => todo.value().description === value).length ===
-      1;
+      allTodos().filter((todo) => todo.description === value).length === 1;
     if (valid) {
       setState('VALID');
     } else {
       setState('INVALID', {
         todoUniqueInList: {
-          details: false
+          details: false,
         },
       });
     }
   };
 }
+
+type Todo = {
+  description: FormField<string>;
+  completed: FormField<boolean>;
+};

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import {
   createFormField,
   createFormGroup,
   FormField,
+  FormGroup,
   SetValidationState,
   SignalInputDirective,
   V,
@@ -114,13 +115,12 @@ export class AppComponent {
     return {
       username,
       passwords: createFormGroup(() => {
-        const password = createFormField('', {
+        const password = createFormField('', (pw) => ({
           validators: [
             V.required(),
             {
               validator: V.minLength(5),
-              disable: () =>
-                username.value().toLocaleLowerCase().startsWith('robin'),
+              disable: () => pw().toLocaleLowerCase().startsWith('rob'),
               message: ({
                 currentLength,
                 minLength,
@@ -128,12 +128,12 @@ export class AppComponent {
                 currentLength: number;
                 minLength: number;
               }) =>
-                `Password must be at least ${minLength} characters long. Add at least ${
+                `Password must be at least ${minLength} characters long or start with rob. Add at least ${
                   minLength - currentLength
-                } characters`,
+                } characters or change '${pw().substring(0,3)}' to rob`,
             },
           ],
-        });
+        }));
 
         return {
           password,
@@ -143,7 +143,7 @@ export class AppComponent {
           }),
         };
       }),
-      todos: createFormGroup<SettableSignal<Todo[]>>(
+      todos: createFormGroup<SettableSignal<FormGroup<Todo>[]>>(
         () => {
           return signal([]);
         },
@@ -171,7 +171,7 @@ export class AppComponent {
 
   addTodo() {
     this.form.controls.todos.controls.mutate((todos) =>
-      (todos as any).push(this.createTodo())
+      todos.push(this.createTodo())
     );
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,6 +11,7 @@ import {
   SignalInputErrorDirective,
   SignalInputDebounceDirective,
   withErrorComponent,
+  UnwrappedFormGroup,
 } from '@signal-form';
 import { JsonPipe, NgFor, NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -130,7 +131,7 @@ export class AppComponent {
               }) =>
                 `Password must be at least ${minLength} characters long or start with rob. Add at least ${
                   minLength - currentLength
-                } characters or change '${pw().substring(0,3)}' to rob`,
+                } characters or change '${pw().substring(0, 3)}' to rob`,
             },
           ],
         }));
@@ -139,7 +140,9 @@ export class AppComponent {
           password,
           passwordConfirmation: createFormField<string | undefined>(undefined, {
             validators: [V.required(), V.equalsTo(password.value)],
-            hidden: () => password.value() === '',
+            hidden: () => {
+              return password.value() === '';
+            },
           }),
         };
       }),
@@ -161,7 +164,9 @@ export class AppComponent {
           validators: [
             V.required(),
             V.minLength(5),
-            todoUniqueInList(this.form.controls.todos.value as any),
+            todoUniqueInList(
+              this.form.controls.todos.value as unknown as Signal<Todo[]>
+            ),
           ],
         }),
         completed: createFormField(false),

--- a/src/signal-forms/form-group.ts
+++ b/src/signal-forms/form-group.ts
@@ -11,16 +11,20 @@ import {
   Validator,
 } from './validation';
 
+export type UnwrappedFormGroup<Controls> = {
+  [K in keyof Controls]: Controls[K] extends FormField<infer V>
+    ? V
+    : Controls[K] extends FormGroup<infer G>
+    ? UnwrappedFormGroup<G>
+    : never;
+};
+
 export type FormGroup<
   Controls extends
     | { [p: string]: FormField | FormGroup }
     | SettableSignal<any[]> = {}
 > = {
-  value: Signal<{
-    [K in keyof Controls]: Controls[K] extends FormField
-      ? Controls[K]['value']
-      : never;
-  }>;
+  value: Signal<UnwrappedFormGroup<Controls>>;
   controls: { [K in keyof Controls]: Controls[K] };
   state: Signal<ValidationState>;
   dirtyState: Signal<DirtyState>;

--- a/src/signal-forms/form-group.ts
+++ b/src/signal-forms/form-group.ts
@@ -1,5 +1,5 @@
-import {computed, isSignal, SettableSignal, Signal,} from '@angular/core';
-import {DirtyState, FormField, TouchedState} from './form-field';
+import { computed, isSignal, SettableSignal, Signal } from '@angular/core';
+import { DirtyState, FormField, TouchedState } from './form-field';
 import {
   computeErrors,
   computeErrorsArray,
@@ -12,7 +12,8 @@ import {
 } from './validation';
 
 export type FormGroup<
-  Controls extends | { [p: string]: FormField | FormGroup }
+  Controls extends
+    | { [p: string]: FormField | FormGroup }
     | SettableSignal<any[]> = {}
 > = {
   value: Signal<{
@@ -35,9 +36,15 @@ export type FormGroupOptions = {
 };
 
 export function createFormGroup<
-  Controls extends | { [p: string]: FormField | FormGroup }
+  Controls extends
+    | { [p: string]: FormField | FormGroup }
     | SettableSignal<any[]>
->(formGroup: Controls, options?: FormGroupOptions): FormGroup<Controls> {
+>(
+  formGroupCreator: () => Controls,
+  options?: FormGroupOptions
+): FormGroup<Controls> {
+  const formGroup = formGroupCreator();
+
   const valueSignal = computed(() => {
     const fg =
       typeof formGroup === 'function' && isSignal(formGroup)
@@ -90,8 +97,10 @@ export function createFormGroup<
           ? formGroup()
           : formGroup;
       const childErrors = Object.entries(fg).map(([key, f]) => {
-        return (f as any).errorsArray().map((e: any) => ({...e, path: e.path ? (key + '.' + e.path) : key}));
-      })
+        return (f as any)
+          .errorsArray()
+          .map((e: any) => ({ ...e, path: e.path ? key + '.' + e.path : key }));
+      });
       return myErrors.concat(...childErrors);
     }),
     dirtyState: computed(() => {


### PR DESCRIPTION
Remove the need of `reference`.
What do you think @goetzrobin ?
It needs some type reworks, but this was just another test... 😅

This doesn't support getting access to your own form field (as with the password `@@` validation).
To allow that we can rework this to the following signature:

```ts
password: createFormField('', (myValue) => {
  return { disable: () => myValue() === '' }
}),
```