### PR TITLE
feat: introduce form builder that automatically adds injector

### DIFF
--- a/apps/example/src/app/app.component.ts
+++ b/apps/example/src/app/app.component.ts
@@ -1,10 +1,8 @@
-import {Component, inject, Injector, Signal, signal, WritableSignal} from '@angular/core';
+import {Component, inject, Signal, signal, WritableSignal} from '@angular/core';
 import {
-  createFormField,
-  createFormGroup,
   FormField,
   FormGroup,
-  SetValidationState,
+  SetValidationState, SignalFormBuilder,
   SignalInputDebounceDirective,
   SignalInputDirective,
   SignalInputErrorDirective,
@@ -107,16 +105,16 @@ import {CustomErrorComponent} from './custom-input-error.component';
   providers: [withErrorComponent(CustomErrorComponent)],
 })
 export class AppComponent {
-  private injector = inject(Injector)
-  form = createFormGroup(() => {
-    const username = createFormField('', {
+  private sfb = inject(SignalFormBuilder)
+  form = this.sfb.createFormGroup(() => {
+    const username = this.sfb.createFormField('', {
       validators: [V.required(), uniqueUsername()],
     });
 
     return {
       username,
-      passwords: createFormGroup(() => {
-        const password = createFormField('', (pw) => ({
+      passwords: this.sfb.createFormGroup(() => {
+        const password = this.sfb.createFormField('', (pw) => ({
           validators: [
             V.required(),
             {
@@ -138,7 +136,7 @@ export class AppComponent {
 
         return {
           password,
-          passwordConfirmation: createFormField<string | undefined>(undefined, {
+          passwordConfirmation: this.sfb.createFormField<string | undefined>(undefined, {
             validators: [V.required(), V.equalsTo(password.value)],
             hidden: () => {
               return password.value() === '';
@@ -146,7 +144,7 @@ export class AppComponent {
           }),
         };
       }),
-      todos: createFormGroup<WritableSignal<FormGroup<Todo>[]>>(
+      todos: this.sfb.createFormGroup<WritableSignal<FormGroup<Todo>[]>>(
         () => {
           return signal([]);
         },
@@ -158,10 +156,9 @@ export class AppComponent {
   });
 
   createTodo = () => {
-    return createFormGroup<Todo>(() => {
+    return this.sfb.createFormGroup<Todo>(() => {
       return {
-        description: createFormField('', {
-          injector: this.injector,
+        description: this.sfb.createFormField('', {
           validators: [
             V.required(),
             V.minLength(5),
@@ -170,12 +167,9 @@ export class AppComponent {
             ),
           ],
         }),
-        completed: createFormField(false, {
-          injector: this.injector
+        completed: this.sfb.createFormField(false, {
         }),
       };
-    }, {
-      injector: this.injector
     });
   };
 

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -3,6 +3,7 @@ import * as V from './lib/validators';
 export * from './lib/validation';
 export * from './lib/form-field';
 export * from './lib/form-group';
+export * from './lib/form-builder';
 export * from './lib/signal-input.directive';
 export * from './lib/signal-input-error.directive';
 export * from './lib/signal-input-error.token';

--- a/packages/platform/src/lib/form-builder.ts
+++ b/packages/platform/src/lib/form-builder.ts
@@ -1,0 +1,27 @@
+import {inject, Injectable, Injector, WritableSignal} from "@angular/core";
+import {FormField, createFormField, FormFieldOptions, FormFieldOptionsCreator} from "./form-field";
+import {FormGroup, createFormGroup,FormGroupOptions} from "./form-group";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SignalFormBuilder {
+  private injector = inject(Injector);
+
+  public createFormField<Value>(
+    value: Value | WritableSignal<Value>,
+    options?: FormFieldOptions | FormFieldOptionsCreator<Value>,
+  ): FormField<Value> {
+    return createFormField(value, options, this.injector);
+  }
+
+  public createFormGroup<
+    Controls extends | { [p: string]: FormField | FormGroup }
+      | WritableSignal<any[]>
+  >(
+    formGroupCreator: () => Controls,
+    options?: FormGroupOptions
+  ): FormGroup<Controls> {
+    return createFormGroup(formGroupCreator, options, this.injector);
+  }
+}

--- a/packages/platform/src/lib/form-field.ts
+++ b/packages/platform/src/lib/form-field.ts
@@ -31,20 +31,20 @@ export type FormFieldOptions = {
   validators?: Validator<any>[];
   hidden?: () => boolean;
   disabled?: () => boolean;
-  injector?: Injector;
 };
 export type FormFieldOptionsCreator<T> = (value: Signal<T>) => FormFieldOptions
 
 export function createFormField<Value>(
   value: Value | WritableSignal<Value>,
   options?: FormFieldOptions | FormFieldOptionsCreator<Value>,
+  injector?: Injector
 ): FormField<Value> {
   const valueSignal =
     // needed until types for writable signal are fixed
     (typeof value === 'function' && isSignal(value) ? value : signal(value)) as WritableSignal<Value>;
   const finalOptions = options && typeof options === 'function' ? options(valueSignal) : options;
 
-  const validatorsSignal = computeValidators(valueSignal, finalOptions?.validators, finalOptions?.injector);
+  const validatorsSignal = computeValidators(valueSignal, finalOptions?.validators, injector);
   const validateStateSignal = computeValidateState(validatorsSignal);
 
   const errorsSignal = computeErrors(validateStateSignal);
@@ -63,7 +63,7 @@ export function createFormField<Value>(
     }
   }, {
     allowSignalWrites: true,
-    injector: finalOptions?.injector
+    injector: injector
   });
 
   if (finalOptions?.hidden) {
@@ -72,7 +72,7 @@ export function createFormField<Value>(
       },
       {
         allowSignalWrites: true,
-        injector: finalOptions.injector
+        injector: injector
       });
   }
 
@@ -82,7 +82,7 @@ export function createFormField<Value>(
       },
       {
         allowSignalWrites: true,
-        injector: finalOptions.injector
+        injector: injector
       });
   }
 

--- a/packages/platform/src/lib/form-group.ts
+++ b/packages/platform/src/lib/form-group.ts
@@ -15,13 +15,12 @@ export type UnwrappedFormGroup<Controls> = {
   [K in keyof Controls]: Controls[K] extends FormField<infer V>
     ? V
     : Controls[K] extends FormGroup<infer G>
-    ? UnwrappedFormGroup<G>
-    : never;
+      ? UnwrappedFormGroup<G>
+      : never;
 };
 
 export type FormGroup<
-  Controls extends
-    | { [p: string]: FormField | FormGroup }
+  Controls extends | { [p: string]: FormField | FormGroup }
     | WritableSignal<any[]> = {}
 > = {
   value: Signal<UnwrappedFormGroup<Controls>>;
@@ -37,16 +36,15 @@ export type FormGroupOptions = {
   validators?: Validator<any>[];
   hidden?: () => boolean;
   disabled?: () => boolean;
-  injector?: Injector;
 };
 
 export function createFormGroup<
-  Controls extends
-    | { [p: string]: FormField | FormGroup }
+  Controls extends | { [p: string]: FormField | FormGroup }
     | WritableSignal<any[]>
 >(
   formGroupCreator: () => Controls,
-  options?: FormGroupOptions
+  options?: FormGroupOptions,
+  injector?: Injector
 ): FormGroup<Controls> {
   const formGroup = formGroupCreator();
 
@@ -65,7 +63,7 @@ export function createFormGroup<
     }, {} as any);
   });
 
-  const validatorsSignal = computeValidators(valueSignal, options?.validators, options?.injector);
+  const validatorsSignal = computeValidators(valueSignal, options?.validators, injector);
   const validateStateSignal = computeValidateState(validatorsSignal);
 
   const errorsSignal = computeErrors(validateStateSignal);
@@ -104,7 +102,7 @@ export function createFormGroup<
       const childErrors = Object.entries(fg).map(([key, f]) => {
         return (f as any)
           .errorsArray()
-          .map((e: any) => ({ ...e, path: e.path ? key + '.' + e.path : key }));
+          .map((e: any) => ({...e, path: e.path ? key + '.' + e.path : key}));
       });
       return myErrors.concat(...childErrors);
     }),


### PR DESCRIPTION
since we use effects we need to either create our form elements in an injection context or pass in an injector when generating new fields at runtime. This PR creates an injectable form builder that automatically adds the injector and allows users to create elements in services,
components, directives without having to worry about when and when not to pass the injector