### PR TITLE
feat: introduce helper function to create injectable signal forms

### DIFF
--- a/apps/example/src/app/app.component.ts
+++ b/apps/example/src/app/app.component.ts
@@ -1,225 +1,25 @@
-import {Component, inject, Signal, signal, WritableSignal} from '@angular/core';
-import {
-  FormField,
-  FormGroup,
-  SetValidationState, SignalFormBuilder,
-  SignalInputDebounceDirective,
-  SignalInputDirective,
-  SignalInputErrorDirective,
-  V,
-  Validator,
-  withErrorComponent,
-} from '@ng-signal-form/platform';
-import {JsonPipe, NgFor, NgIf} from '@angular/common';
-import {FormsModule} from '@angular/forms';
-import {CustomErrorComponent} from './custom-input-error.component';
+import {Component} from '@angular/core';
+import {RouterLink, RouterOutlet} from "@angular/router";
 
 @Component({
   selector: 'app-root',
+  imports: [
+    RouterLink,
+    RouterOutlet
+  ],
   template: `
-    <div class="container">
-      <div>
-        <div>
-          <label>Username (tim is invalid)</label>
-          <small>{{ form.controls.username.errors() | json }}</small>
-          <input
-            ngModel
-            [debounce]="700"
-            [formField]="form.controls.username"
-          />
-        </div>
-
-        <div>
-          <label>Password </label>
-          <small>{{
-            form.controls.passwords.controls.password.errors() | json
-          }}</small>
-          <input
-            ngModel
-            [formField]="form.controls.passwords.controls.password"
-          />
-        </div>
-
-        <div
-          *ngIf="
-            !form.controls.passwords.controls.passwordConfirmation.hidden()
-          "
-        >
-          <label>Password Confirmation</label>
-          <small>{{
-            form.controls.passwords.controls.passwordConfirmation.errors()
-              | json
-          }}</small>
-          <input
-            ngModel
-            [formField]="form.controls.passwords.controls.passwordConfirmation"
-          />
-        </div>
-
-        <div>
-          <button (click)="addTodo()">Add todo</button>
-          <small>{{ form.controls.todos.errors() | json }}</small>
-
-          <div *ngFor="let todo of $any(form.controls.todos.controls)()">
-            <label>Todo</label>
-            <small>{{ todo.controls.description.errors() | json }}</small>
-            <input
-              type="checkbox"
-              ngModel
-              [formField]="todo.controls.completed"
-            />
-            <input ngModel [formField]="todo.controls.description" />
-          </div>
-        </div>
-      </div>
-
-      <div>
-        <h3>States</h3>
-        <pre
-          >{{
-            {
-              state: form.state(),
-              dirtyState: form.dirtyState(),
-              touchedState: form.touchedState()
-            } | json
-          }}
-    </pre>
-        <h3>Value</h3>
-        <pre>{{ form.value() | json }}</pre>
-
-        <h3>Errors</h3>
-        <pre>{{ form.errorsArray() | json }}</pre>
-      </div>
-    </div>
+    <nav class="mainNav">
+      <ul>
+        <li>
+          <a routerLink="simple-form">Simple form</a>
+        </li>
+        <li>
+          <a routerLink="multi-page-form">Multipage form</a>
+        </li>
+      </ul>
+    </nav>
+    <router-outlet/>
   `,
   standalone: true,
-  imports: [
-    JsonPipe,
-    FormsModule,
-    SignalInputDirective,
-    SignalInputErrorDirective,
-    NgIf,
-    NgFor,
-    SignalInputDebounceDirective,
-  ],
-  providers: [withErrorComponent(CustomErrorComponent)],
 })
-export class AppComponent {
-  private sfb = inject(SignalFormBuilder)
-  form = this.sfb.createFormGroup(() => {
-    const username = this.sfb.createFormField('', {
-      validators: [V.required(), uniqueUsername()],
-    });
-
-    return {
-      username,
-      passwords: this.sfb.createFormGroup(() => {
-        const password = this.sfb.createFormField('', (pw) => ({
-          validators: [
-            V.required(),
-            {
-              validator: V.minLength(5),
-              disable: () => pw().toLocaleLowerCase().startsWith('rob'),
-              message: ({
-                currentLength,
-                minLength,
-              }: {
-                currentLength: number;
-                minLength: number;
-              }) =>
-                `Password must be at least ${minLength} characters long or start with rob. Add at least ${
-                  minLength - currentLength
-                } characters or change '${pw().substring(0, 3)}' to rob`,
-            },
-          ],
-        }));
-
-        return {
-          password,
-          passwordConfirmation: this.sfb.createFormField<string | undefined>(undefined, {
-            validators: [V.required(), V.equalsTo(password.value)],
-            hidden: () => {
-              return password.value() === '';
-            },
-          }),
-        };
-      }),
-      todos: this.sfb.createFormGroup<WritableSignal<FormGroup<Todo>[]>>(
-        () => {
-          return signal([]);
-        },
-        {
-          validators: [V.minLength(1)],
-        }
-      ),
-    };
-  });
-
-  createTodo = () => {
-    return this.sfb.createFormGroup<Todo>(() => {
-      return {
-        description: this.sfb.createFormField('', {
-          validators: [
-            V.required(),
-            V.minLength(5),
-            todoUniqueInList(
-              this.form.controls.todos.value as unknown as Signal<Todo[]>
-            ),
-          ],
-        }),
-        completed: this.sfb.createFormField(false, {
-        }),
-      };
-    });
-  };
-
-  addTodo() {
-    this.form.controls.todos.controls.mutate((todos) =>
-      todos.push(this.createTodo())
-    );
-  }
-}
-
-function uniqueUsername<Value>(): Validator<Value> {
-  return (value: Value, setState: SetValidationState) => {
-    setState('PENDING');
-    setTimeout(() => {
-      const valid = value !== 'tim';
-      if (valid) {
-        setState('VALID');
-      } else {
-        setState('INVALID', {
-          uniqueUsername: {
-            details: false,
-          },
-        });
-      }
-    }, 3000);
-  };
-}
-
-function todoUniqueInList<Value>(allTodos: Signal<Todo[]>): Validator<Value> {
-  return (value: Value, setState: SetValidationState) => {
-    if (value === '' || value === null) {
-      setState('VALID');
-      return;
-    }
-
-    const valid =
-      allTodos().filter((todo) => todo.description === value).length === 1;
-    if (valid) {
-      setState('VALID');
-    } else {
-      setState('INVALID', {
-        todoUniqueInList: {
-          details: false,
-        },
-      });
-    }
-  };
-}
-
-type Todo = {
-  description: FormField<string>;
-  completed: FormField<boolean>;
-};
+export class AppComponent {}

--- a/apps/example/src/app/app.routes.ts
+++ b/apps/example/src/app/app.routes.ts
@@ -1,0 +1,17 @@
+import {Routes} from "@angular/router";
+
+export const routes: Routes = [
+  {
+    path: '',
+    redirectTo: 'simple-form',
+    pathMatch: 'full'
+  },
+  {
+    path: 'simple-form',
+    loadComponent: () => import('./simple-form.component')
+  },
+  {
+    path: 'multi-page-form',
+    loadChildren: () => import('./multi-page-form/multi-page-form.routes')
+  }
+];

--- a/apps/example/src/app/multi-page-form/form-nav.component.ts
+++ b/apps/example/src/app/multi-page-form/form-nav.component.ts
@@ -1,0 +1,25 @@
+import {RouterLink} from "@angular/router";
+import {Component} from "@angular/core";
+
+@Component({
+  selector: 'app-form-nav',
+  standalone: true,
+  imports: [RouterLink],
+  template: `
+    <nav>
+      <ol>
+        <li>
+          <a routerLink="/multi-page-form/step-1">Step 1</a>
+        </li>
+        <li>
+          <a routerLink="/multi-page-form/step-2">Step 2</a>
+        </li>
+        <li>
+          <a routerLink="/multi-page-form/review">Review</a>
+        </li>
+      </ol>
+    </nav>
+  `
+})
+export class FormNavComponent {
+}

--- a/apps/example/src/app/multi-page-form/multi-page-form.routes.ts
+++ b/apps/example/src/app/multi-page-form/multi-page-form.routes.ts
@@ -1,0 +1,34 @@
+import {Routes} from "@angular/router";
+import {provideSignalForm} from "./multi-page.form";
+import {withErrorComponent} from "@ng-signal-form/platform";
+import {CustomErrorComponent} from "../custom-input-error.component";
+
+export const routes: Routes = [
+  {
+    path: '',
+    redirectTo: 'step-1',
+    pathMatch: 'full'
+  },
+  {
+    path: '',
+    providers: [
+      provideSignalForm(),
+      withErrorComponent(CustomErrorComponent)
+    ],
+    children: [
+      {
+        path: 'step-1',
+        loadComponent: () => import('./step1.component')
+      },
+      {
+        path: 'step-2',
+        loadComponent: () => import('./step2.component')
+      },
+      {
+        path: 'review',
+        loadComponent: () => import('./review.component')
+      }
+    ]
+  }
+];
+export default routes;

--- a/apps/example/src/app/multi-page-form/multi-page.form.ts
+++ b/apps/example/src/app/multi-page-form/multi-page.form.ts
@@ -1,0 +1,17 @@
+import {V, createFormField, createFormGroup, createInjectableSignalForm} from "@ng-signal-form/platform";
+import {signal} from "@angular/core";
+
+export const {injectSignalForm, provideSignalForm} = createInjectableSignalForm(() => createFormGroup(() => ({
+  step1: createFormGroup(() => ({
+    firstName: createFormField('', {validators: [V.required()]}),
+    lastName: createFormField('', {validators: [V.required()]}),
+  })),
+  step2: createFormGroup(() => ({
+    street: createFormField('', {validators: [V.required()]}),
+    zip: createFormField<number | undefined>(undefined, {
+      validators: [V.required(), V.equalsTo(signal(1234))]
+    }),
+    city: createFormField('', {validators: [V.required()]}),
+    country: createFormField('', {validators: [V.required()]}),
+  }))
+})));

--- a/apps/example/src/app/multi-page-form/review.component.ts
+++ b/apps/example/src/app/multi-page-form/review.component.ts
@@ -1,0 +1,33 @@
+import {Component} from "@angular/core";
+import {JsonPipe} from "@angular/common";
+import {injectSignalForm} from "./multi-page.form";
+import {FormNavComponent} from "./form-nav.component";
+
+@Component({
+  selector: 'app-review',
+  standalone: true,
+  imports: [JsonPipe, FormNavComponent],
+  template: `
+    <app-form-nav/>
+    <div>
+      <h3>States</h3>
+      <pre
+      >{{
+        {
+          state: form.state(),
+          dirtyState: form.dirtyState(),
+          touchedState: form.touchedState()
+        } | json
+        }}
+    </pre>
+      <h3>Value</h3>
+      <pre>{{ form.value() | json }}</pre>
+
+      <h3>Errors</h3>
+      <pre>{{ form.errorsArray() | json }}</pre>
+    </div>
+  `,
+})
+export default class ReviewComponent {
+  public form = injectSignalForm()
+}

--- a/apps/example/src/app/multi-page-form/step1.component.ts
+++ b/apps/example/src/app/multi-page-form/step1.component.ts
@@ -1,0 +1,45 @@
+import {Component} from "@angular/core";
+import {injectSignalForm} from "./multi-page.form";
+import {FormsModule} from "@angular/forms";
+import {SignalInputDirective, SignalInputErrorDirective} from "@ng-signal-form/platform";
+import {JsonPipe} from "@angular/common";
+import {FormNavComponent} from "./form-nav.component";
+
+@Component({
+  selector: 'app-step-1',
+  standalone: true,
+  imports: [
+    JsonPipe,
+    FormsModule,
+    SignalInputDirective,
+    SignalInputErrorDirective,
+    FormNavComponent,
+  ],
+  template: `
+    <app-form-nav/>
+    <div>
+
+      <div>
+        <label>First name</label>
+        <small>{{ form.controls.firstName.errors() | json }}</small>
+        <input
+          ngModel
+          [formField]="form.controls.firstName"
+        />
+      </div>
+
+      <div>
+        <label>Last name</label>
+        <small>{{ form.controls.lastName.errors() | json }}</small>
+        <input
+          ngModel
+          [formField]="form.controls.lastName"
+        />
+      </div>
+
+    </div>
+  `,
+})
+export default class Step1Component {
+  public form = injectSignalForm().controls.step1;
+}

--- a/apps/example/src/app/multi-page-form/step2.component.ts
+++ b/apps/example/src/app/multi-page-form/step2.component.ts
@@ -1,0 +1,63 @@
+import {Component} from "@angular/core";
+import {JsonPipe} from "@angular/common";
+import {FormsModule} from "@angular/forms";
+import {SignalInputDirective, SignalInputErrorDirective} from "@ng-signal-form/platform";
+import {injectSignalForm} from "./multi-page.form";
+import {FormNavComponent} from "./form-nav.component";
+
+@Component({
+  selector: 'app-step-2',
+  standalone: true,
+  imports: [
+    JsonPipe,
+    FormsModule,
+    SignalInputDirective,
+    SignalInputErrorDirective,
+    FormNavComponent,
+  ],
+  template: `
+    <app-form-nav/>
+    <div>
+      <div>
+        <label>Street</label>
+        <small>{{ form.controls.street.errors() | json }}</small>
+        <input
+          ngModel
+          [formField]="form.controls.street"
+        />
+      </div>
+
+      <div>
+        <label>ZIP (must be 1234)</label>
+        <small>{{ form.controls.zip.errors() | json }}</small>
+        <input
+          type="number"
+          ngModel
+          [formField]="form.controls.zip"
+        />
+      </div>
+
+      <div>
+        <label>City</label>
+        <small>{{ form.controls.city.errors() | json }}</small>
+        <input
+          ngModel
+          [formField]="form.controls.city"
+        />
+      </div>
+
+      <div>
+        <label>Country</label>
+        <small>{{ form.controls.country.errors() | json }}</small>
+        <input
+          ngModel
+          [formField]="form.controls.country"
+        />
+      </div>
+
+    </div>
+  `,
+})
+export default class Step2Component {
+  public form = injectSignalForm().controls.step2;
+}

--- a/apps/example/src/app/simple-form.component.ts
+++ b/apps/example/src/app/simple-form.component.ts
@@ -1,0 +1,225 @@
+import {Component, inject, Signal, signal, WritableSignal} from '@angular/core';
+import {
+  FormField,
+  FormGroup,
+  SetValidationState, SignalFormBuilder,
+  SignalInputDebounceDirective,
+  SignalInputDirective,
+  SignalInputErrorDirective,
+  V,
+  Validator,
+  withErrorComponent,
+} from '@ng-signal-form/platform';
+import {JsonPipe, NgFor, NgIf} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+import {CustomErrorComponent} from './custom-input-error.component';
+
+@Component({
+  selector: 'app-simple-form',
+  template: `
+    <div class="container">
+      <div>
+        <div>
+          <label>Username (tim is invalid)</label>
+          <small>{{ form.controls.username.errors() | json }}</small>
+          <input
+            ngModel
+            [debounce]="700"
+            [formField]="form.controls.username"
+          />
+        </div>
+
+        <div>
+          <label>Password </label>
+          <small>{{
+            form.controls.passwords.controls.password.errors() | json
+          }}</small>
+          <input
+            ngModel
+            [formField]="form.controls.passwords.controls.password"
+          />
+        </div>
+
+        <div
+          *ngIf="
+            !form.controls.passwords.controls.passwordConfirmation.hidden()
+          "
+        >
+          <label>Password Confirmation</label>
+          <small>{{
+            form.controls.passwords.controls.passwordConfirmation.errors()
+              | json
+          }}</small>
+          <input
+            ngModel
+            [formField]="form.controls.passwords.controls.passwordConfirmation"
+          />
+        </div>
+
+        <div>
+          <button (click)="addTodo()">Add todo</button>
+          <small>{{ form.controls.todos.errors() | json }}</small>
+
+          <div *ngFor="let todo of $any(form.controls.todos.controls)()">
+            <label>Todo</label>
+            <small>{{ todo.controls.description.errors() | json }}</small>
+            <input
+              type="checkbox"
+              ngModel
+              [formField]="todo.controls.completed"
+            />
+            <input ngModel [formField]="todo.controls.description" />
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <h3>States</h3>
+        <pre
+          >{{
+            {
+              state: form.state(),
+              dirtyState: form.dirtyState(),
+              touchedState: form.touchedState()
+            } | json
+          }}
+    </pre>
+        <h3>Value</h3>
+        <pre>{{ form.value() | json }}</pre>
+
+        <h3>Errors</h3>
+        <pre>{{ form.errorsArray() | json }}</pre>
+      </div>
+    </div>
+  `,
+  standalone: true,
+  imports: [
+    JsonPipe,
+    FormsModule,
+    SignalInputDirective,
+    SignalInputErrorDirective,
+    NgIf,
+    NgFor,
+    SignalInputDebounceDirective,
+  ],
+  providers: [withErrorComponent(CustomErrorComponent)],
+})
+export default class SimpleFormComponent {
+  private sfb = inject(SignalFormBuilder)
+  form = this.sfb.createFormGroup(() => {
+    const username = this.sfb.createFormField('', {
+      validators: [V.required(), uniqueUsername()],
+    });
+
+    return {
+      username,
+      passwords: this.sfb.createFormGroup(() => {
+        const password = this.sfb.createFormField('', (pw) => ({
+          validators: [
+            V.required(),
+            {
+              validator: V.minLength(5),
+              disable: () => pw().toLocaleLowerCase().startsWith('rob'),
+              message: ({
+                          currentLength,
+                          minLength,
+                        }: {
+                currentLength: number;
+                minLength: number;
+              }) =>
+                `Password must be at least ${minLength} characters long or start with rob. Add at least ${
+                  minLength - currentLength
+                } characters or change '${pw().substring(0, 3)}' to rob`,
+            },
+          ],
+        }));
+
+        return {
+          password,
+          passwordConfirmation: this.sfb.createFormField<string | undefined>(undefined, {
+            validators: [V.required(), V.equalsTo(password.value)],
+            hidden: () => {
+              return password.value() === '';
+            },
+          }),
+        };
+      }),
+      todos: this.sfb.createFormGroup<WritableSignal<FormGroup<Todo>[]>>(
+        () => {
+          return signal([]);
+        },
+        {
+          validators: [V.minLength(1)],
+        }
+      ),
+    };
+  });
+
+  createTodo = () => {
+    return this.sfb.createFormGroup<Todo>(() => {
+      return {
+        description: this.sfb.createFormField('', {
+          validators: [
+            V.required(),
+            V.minLength(5),
+            todoUniqueInList(
+              this.form.controls.todos.value as unknown as Signal<Todo[]>
+            ),
+          ],
+        }),
+        completed: this.sfb.createFormField(false, {
+        }),
+      };
+    });
+  };
+
+  addTodo() {
+    this.form.controls.todos.controls.mutate((todos) =>
+      todos.push(this.createTodo())
+    );
+  }
+}
+
+function uniqueUsername<Value>(): Validator<Value> {
+  return (value: Value, setState: SetValidationState) => {
+    setState('PENDING');
+    setTimeout(() => {
+      const valid = value !== 'tim';
+      if (valid) {
+        setState('VALID');
+      } else {
+        setState('INVALID', {
+          uniqueUsername: {
+            details: false,
+          },
+        });
+      }
+    }, 3000);
+  };
+}
+
+function todoUniqueInList<Value>(allTodos: Signal<Todo[]>): Validator<Value> {
+  return (value: Value, setState: SetValidationState) => {
+    if (value === '' || value === null) {
+      setState('VALID');
+      return;
+    }
+
+    const valid =
+      allTodos().filter((todo) => todo.description === value).length === 1;
+    if (valid) {
+      setState('VALID');
+    } else {
+      setState('INVALID', {
+        todoUniqueInList: {
+          details: false,
+        },
+      });
+    }
+  };
+}
+
+type Todo = {
+  description: FormField<string>;
+  completed: FormField<boolean>;
+};

--- a/apps/example/src/main.ts
+++ b/apps/example/src/main.ts
@@ -1,5 +1,9 @@
 import {bootstrapApplication} from "@angular/platform-browser";
 import {AppComponent} from "./app/app.component";
+import {provideRouter} from "@angular/router";
+import {routes} from "./app/app.routes";
 
 
-bootstrapApplication(AppComponent)
+bootstrapApplication(AppComponent, {
+  providers: [provideRouter(routes)]
+})

--- a/apps/example/src/styles.css
+++ b/apps/example/src/styles.css
@@ -45,3 +45,20 @@ div {
 small {
   margin-left: 0.2em;
 }
+
+
+nav ul {
+  padding: 0;
+  display: flex;
+}
+nav ul li {
+  list-style: none;
+  margin-right: 1rem;
+}
+nav ol {
+  padding: 0;
+  display: flex;
+}
+nav ol li {
+  margin: 0 1rem;
+}

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -9,5 +9,6 @@ export * from './lib/signal-input-error.directive';
 export * from './lib/signal-input-error.token';
 export * from './lib/signal-input-debounce.directive';
 export * from './lib/signal-input-modifier.token';
+export * from './lib/injectable-signal-form.token';
 
 export { V };

--- a/packages/platform/src/lib/injectable-signal-form.token.ts
+++ b/packages/platform/src/lib/injectable-signal-form.token.ts
@@ -1,0 +1,18 @@
+import {inject, InjectionToken, Provider} from "@angular/core";
+import {FormGroup} from "./form-group";
+import {FormField} from "./form-field";
+
+export const INJECTABLE_SIGNAL_FORM
+  = new InjectionToken<FormGroup | FormField>('ng-signal-form injectable form');
+
+export const createInjectableSignalForm =<Form extends (FormGroup<any> | FormField<any>)> (formCreator: () => Form) => {
+  const provideSignalForm = (): Provider => ({
+    provide: INJECTABLE_SIGNAL_FORM,
+    useFactory: () => formCreator()
+  })
+
+  const injectSignalForm = () => inject(INJECTABLE_SIGNAL_FORM as InjectionToken<ReturnType<typeof formCreator>>);
+
+  return {provideSignalForm, injectSignalForm}
+}
+

--- a/packages/platform/src/lib/signal-input.directive.ts
+++ b/packages/platform/src/lib/signal-input.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, effect, inject, Input, OnInit} from '@angular/core';
+import {ChangeDetectorRef, Directive, effect, inject, Input, OnInit, signal} from '@angular/core';
 import {NgModel} from '@angular/forms';
 import {FormField} from './form-field';
 import {SIGNAL_INPUT_MODIFIER, SignalInputModifier} from "./signal-input-modifier.token";
@@ -51,5 +51,12 @@ export class SignalInputDirective implements OnInit {
         this.modifiers[0].registerOnSet(this.formField.value.set)
       }
     }
+
+    // needed for view to update on initial load of multi-page-form correctly. need to investigate why
+    setTimeout(() => this.model.control.setValue(this.formField?.value(), {
+      emitEvent: false,
+      emitViewToModelChange: false,
+      emitModelToViewChange: true,
+    }));
   }
 }


### PR DESCRIPTION
this helper would allow us to create a typesafe signal form on a (parent) route level and inject the shared form in a typesafe way into the child components of such a route.