### PR TITLE
feat: introduce reset function for FormField and FormGroup

### DIFF
--- a/apps/example/src/app/simple-form.component.ts
+++ b/apps/example/src/app/simple-form.component.ts
@@ -78,6 +78,8 @@ import { CustomErrorComponent } from './custom-input-error.component';
             <input ngModel [formField]="todo.controls.description" />
           </div>
         </div>
+
+        <button (click)="reset()">Reset form </button>
       </div>
 
       <div>
@@ -186,6 +188,10 @@ export default class SimpleFormComponent {
     this.form.controls.todos.controls.mutate((todos) =>
       todos.push(this.createTodo())
     );
+  }
+
+  reset() {
+    this.form.reset();
   }
 }
 

--- a/packages/platform/src/lib/form-field.ts
+++ b/packages/platform/src/lib/form-field.ts
@@ -25,6 +25,8 @@ export type FormField<Value = unknown> = {
   disabled: Signal<boolean>;
   markAsTouched: () => void;
   markAsDirty: () => void;
+  reset: () => void;
+  registerOnReset: (fn: (value: Value) => void) => void
 };
 
 export type FormFieldOptions = {
@@ -86,6 +88,9 @@ export function createFormField<Value>(
       });
   }
 
+  const defaultValue = typeof value === 'function' && isSignal(value) ? value() :value;
+  let onReset = (value: Value) => {}
+
   return {
     value: valueSignal,
     errors: errorsSignal,
@@ -97,5 +102,12 @@ export function createFormField<Value>(
     disabled: disabledSignal,
     markAsTouched: () => touchedSignal.set('TOUCHED'),
     markAsDirty: () => dirtySignal.set('DIRTY'),
+    registerOnReset: (fn: (value: Value) => void) => onReset = fn,
+    reset: () => {
+      valueSignal.set(defaultValue);
+      touchedSignal.set('UNTOUCHED');
+      dirtySignal.set('PRISTINE');
+      onReset(defaultValue);
+    }
   };
 }

--- a/packages/platform/src/lib/form-group.ts
+++ b/packages/platform/src/lib/form-group.ts
@@ -30,6 +30,7 @@ export type FormGroup<
   touchedState: Signal<TouchedState>;
   errors: Signal<{}>;
   errorsArray: Signal<InvalidDetails[]>;
+  reset: () => void;
 };
 
 export type FormGroupOptions = {
@@ -47,6 +48,8 @@ export function createFormGroup<
   injector?: Injector
 ): FormGroup<Controls> {
   const formGroup = formGroupCreator();
+  const initialArrayControls =
+    typeof formGroup === 'function' && isSignal(formGroup) ? [...formGroup()] : [];
 
   const valueSignal = computed(() => {
     const fg =
@@ -136,5 +139,20 @@ export function createFormGroup<
 
       return 'UNTOUCHED';
     }),
+    reset: () => {
+      const fg =
+        typeof formGroup === 'function' && isSignal(formGroup)
+          ? formGroup()
+          : formGroup;
+
+      if (Array.isArray(fg)) {
+        // need to create new array to set so change is not swallowed by equality of objects
+        (formGroup as WritableSignal<any[]>).set([...initialArrayControls]);
+        return;
+      }
+      return Object.values(fg).forEach(f => {
+        f.reset()
+      })
+    }
   };
 }

--- a/packages/platform/src/lib/signal-input.directive.ts
+++ b/packages/platform/src/lib/signal-input.directive.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectorRef, Directive, effect, inject, Input, OnInit, signal} from '@angular/core';
+import {Directive, effect, inject, Input, OnInit} from '@angular/core';
 import {NgModel} from '@angular/forms';
 import {FormField} from './form-field';
 import {SIGNAL_INPUT_MODIFIER, SignalInputModifier} from "./signal-input-modifier.token";
@@ -33,6 +33,7 @@ export class SignalInputDirective implements OnInit {
   }
 
   constructor() {
+
     effect(() => {
       if (!this.formField) return
       this.model.control.setValue(this.formField.value(), {
@@ -58,5 +59,7 @@ export class SignalInputDirective implements OnInit {
       emitViewToModelChange: false,
       emitModelToViewChange: true,
     }));
+
+    this.formField?.registerOnReset(value => this.model.control.setValue(value))
   }
 }


### PR DESCRIPTION
For FormFields this will reset the value to the initial value and also set the state to PRISTINE and UNTOUCHED.
For FormGroups this will go through every control and execute the reset function of said control. If the control happens to be an array, it will reset the array to a copy of the initial array.

closes #11