### PR TITLE
fix: change signal input modifier to accept whole value signal instea…

### DIFF
--- a/packages/platform/src/lib/signal-input-modifier.token.ts
+++ b/packages/platform/src/lib/signal-input-modifier.token.ts
@@ -1,9 +1,9 @@
-import {InjectionToken} from "@angular/core";
+import {InjectionToken, WritableSignal} from "@angular/core";
 
 export interface SignalInputModifier {
   onModelChange(value: unknown): void
 
-  registerOnSet(set: (value: unknown) => void): void;
+  registerValueSignal(signal: WritableSignal<unknown>): void;
 }
 
 export const SIGNAL_INPUT_MODIFIER = new InjectionToken<SignalInputModifier>('Custom signal input modifier');

--- a/packages/platform/src/lib/signal-input.directive.ts
+++ b/packages/platform/src/lib/signal-input.directive.ts
@@ -49,7 +49,7 @@ export class SignalInputDirective implements OnInit {
       if (this.modifiers.length !== 1) {
         throw Error('only one modifier per signal input field supported.')
       } else if (this.formField) {
-        this.modifiers[0].registerOnSet(this.formField.value.set)
+        this.modifiers[0].registerValueSignal(this.formField.value)
       }
     }
 


### PR DESCRIPTION
…d of set function

BREAKING CHANGE: we replace the registerOnSet function of the SignalInputModifier with a new registerValueSignal function. We do this, because just assigning the set function to a new property within our class can break (and did break) due to it changing the scope from where set is called. Specifically, we are not calling ourSignal.set anymore this is ourSignal, but instead SignalInputDebounceDirective.set where this is now SignalInputDebounceDirective. To fix this we simply store the whole signal containing the value of our input and call the valueSignal.set in the debounce directive. To enable this our SignalInputModifier interface changes from registerOnSet to registerValueSignal.