### PR TITLE
feat: add classes indicating form field status

### DIFF
--- a/apps/example/src/styles.css
+++ b/apps/example/src/styles.css
@@ -12,17 +12,17 @@ input {
   padding: 0.4em;
 }
 
-input.control-valid {
+input.ng-valid {
   background: hsla(150, 52%, 51%, 0.1);
   outline: 1px solid hsla(150, 52%, 51%, 0.8);
   border: 1px solid hsla(150, 52%, 51%, 0.8);
 }
-input.control-invalid {
+input.ng-invalid {
   background: hsla(356, 100%, 41%, 0.1);
   border: 1px solid hsla(356, 100%, 41%, 0.8);
   outline: 1px solid hsla(356, 100%, 41%, 0.8);
 }
-input.control-pending {
+input.ng-pending {
   background: hsla(208, 100%, 51%, 0.1);
   border: 1px solid hsla(208, 100%, 51%, 0.8);
   outline: 1px solid hsla(208, 100%, 51%, 0.8);

--- a/packages/platform/src/lib/signal-input.directive.ts
+++ b/packages/platform/src/lib/signal-input.directive.ts
@@ -9,9 +9,13 @@ import {SIGNAL_INPUT_MODIFIER, SignalInputModifier} from "./signal-input-modifie
   host: {
     '(ngModelChange)': 'onModelChange($event)',
     '(blur)': 'onBlur()',
-    '[class.control-valid]': 'this.formField?.state() === "VALID"',
-    '[class.control-invalid]': 'this.formField?.state() === "INVALID"',
-    '[class.control-pending]': 'this.formField?.state() === "PENDING"',
+    '[class.ng-valid]': 'this.formField?.state() === "VALID"',
+    '[class.ng-invalid]': 'this.formField?.state() === "INVALID"',
+    '[class.ng-pending]': 'this.formField?.state() === "PENDING"',
+    '[class.ng-pristine]': 'this.formField?.dirtyState() === "PRISTINE"',
+    '[class.ng-dirty]': 'this.formField?.dirtyState() === "DIRTY"',
+    '[class.ng-touched]': 'this.formField?.touchedState() === "TOUCHED"',
+    '[class.ng-untouched]': 'this.formField?.touchedState() === "UNTOUCHED"',
   },
 })
 export class SignalInputDirective implements OnInit {


### PR DESCRIPTION
This PR would add classes to the host element of the SignalInputDirective, which allows us to style the element in a similar manner that we would with Reactive or Template driven Angular forms.