### PR TITLE
fix: add allowSignalWrites inside SignalInputDirective

### DIFF
--- a/packages/platform/src/lib/signal-input.directive.ts
+++ b/packages/platform/src/lib/signal-input.directive.ts
@@ -45,7 +45,7 @@ export class SignalInputDirective implements OnInit {
         emitViewToModelChange: false,
         emitModelToViewChange: true,
       });
-    });
+    }, {allowSignalWrites: true});
   }
 
   public ngOnInit() {


### PR DESCRIPTION
We are setting a signal value inside an effect, but have not added ``{allowSignalWrites: true}`. This causes an error to be thrown.