### PR TITLE
feat: add `email` validator

### DIFF
--- a/apps/example/src/app/app.routes.ts
+++ b/apps/example/src/app/app.routes.ts
@@ -22,4 +22,8 @@ export const routes: Routes = [
     path: 'form-with-cva',
     loadComponent: () => import('./form-with-cva/form-with-cva.component'),
   },
+  {
+    path: 'validators',
+    loadComponent: () => import('./validators/validators.component'),
+  },
 ];

--- a/apps/example/src/app/validators/validators.component.ts
+++ b/apps/example/src/app/validators/validators.component.ts
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+import { JsonPipe } from '@angular/common';
+import {
+  createFormField,
+  createFormGroup,
+  SignalInputDebounceDirective,
+  SignalInputDirective,
+  SignalInputErrorDirective,
+  Validators,
+  withErrorComponent,
+} from '@ng-signal-forms';
+import { FormsModule } from '@angular/forms';
+import { CustomErrorComponent } from '../custom-input-error.component';
+
+@Component({
+  selector: 'validators',
+  standalone: true,
+  imports: [
+    JsonPipe,
+    FormsModule,
+    SignalInputDirective,
+    SignalInputErrorDirective,
+    SignalInputDebounceDirective,
+  ],
+  template: `
+    <div>
+      <label>Email</label>
+      <input ngModel [formField]="form.controls.email" />
+    </div>
+    <pre>{{ form.value() | json }}</pre>
+    <pre>{{ form.errorsArray() | json }}</pre>
+  `,
+  styles: [],
+  providers: [withErrorComponent(CustomErrorComponent)],
+})
+export default class ValidatorsComponent {
+  form = createFormGroup({
+    email: createFormField('', { validators: [Validators.email()] }),
+  });
+}

--- a/apps/example/src/app/validators/validators.component.ts
+++ b/apps/example/src/app/validators/validators.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { JsonPipe } from '@angular/common';
 import {
   createFormField,
@@ -9,26 +9,43 @@ import {
   Validators,
   withErrorComponent,
 } from '@ng-signal-forms';
-import { FormsModule } from '@angular/forms';
+import {
+  FormBuilder,
+  FormControl,
+  FormsModule,
+  ReactiveFormsModule,
+  Validators as ReactiveFormValidators,
+} from '@angular/forms';
 import { CustomErrorComponent } from '../custom-input-error.component';
 
 @Component({
   selector: 'validators',
   standalone: true,
   imports: [
-    JsonPipe,
     FormsModule,
+    JsonPipe,
     SignalInputDirective,
     SignalInputErrorDirective,
     SignalInputDebounceDirective,
+    // TODO - remove before PR
+    ReactiveFormsModule,
   ],
   template: `
     <div>
-      <label>Email</label>
+      <label>Email (signal form)</label>
       <input ngModel [formField]="form.controls.email" />
     </div>
     <pre>{{ form.value() | json }}</pre>
     <pre>{{ form.errorsArray() | json }}</pre>
+
+    <!-- TODO - remove reactive forms point of reference before PR -->
+    <form [formGroup]="reactiveForm">
+      <label>Email (reactive form)</label>
+      <input formControlName="email" type="text" />
+    </form>
+    <pre>{{ reactiveForm.value | json }}</pre>
+    <pre>{{ reactiveForm.errors | json }}</pre>
+    <pre>{{ reactiveForm.controls.email.errors | json }}</pre>
   `,
   styles: [],
   providers: [withErrorComponent(CustomErrorComponent)],
@@ -36,5 +53,11 @@ import { CustomErrorComponent } from '../custom-input-error.component';
 export default class ValidatorsComponent {
   form = createFormGroup({
     email: createFormField('', { validators: [Validators.email()] }),
+  });
+
+  #fb = inject(FormBuilder);
+
+  reactiveForm = this.#fb.group({
+    email: new FormControl('', { validators: ReactiveFormValidators.email }),
   });
 }

--- a/packages/platform/src/lib/validators/email.ts
+++ b/packages/platform/src/lib/validators/email.ts
@@ -1,7 +1,8 @@
 import { SetValidationState, ValidatorFn } from '../validation';
 
 /**
- * @description Email regex is directly from the Angular Forms definition
+ * @description Email regex pattern is directly from the Angular Forms definition.
+ *              Note: other assumptions on validation differ from Angular reactive forms.
  * @link https://github.com/angular/angular/blob/17.3.2/packages/forms/src/validators.ts#L126
  */
 const EMAIL_REGEXP =

--- a/packages/platform/src/lib/validators/email.ts
+++ b/packages/platform/src/lib/validators/email.ts
@@ -18,10 +18,11 @@ export function email(): ValidatorFn {
     if (valid) {
       setState('VALID');
     } else {
-      // TODO - I do not fully trust that I understand what the shape of the `ValidationErrors` should be
       setState('INVALID', {
         email: {
-          details: true,
+          details: {
+            currentValue: value,
+          },
         },
       });
     }

--- a/packages/platform/src/lib/validators/email.ts
+++ b/packages/platform/src/lib/validators/email.ts
@@ -1,0 +1,29 @@
+import { SetValidationState, ValidatorFn } from '../validation';
+
+/**
+ * @description Email regex is directly from the Angular Forms definition
+ * @link https://github.com/angular/angular/blob/17.3.2/packages/forms/src/validators.ts#L126
+ */
+const EMAIL_REGEXP =
+  /^(?=.{1,254}$)(?=.{1,64}@)[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+export function email(): ValidatorFn {
+  return (value: unknown, setState: SetValidationState) => {
+    const valid =
+      value === null ||
+      value === undefined ||
+      typeof value !== 'string' ||
+      EMAIL_REGEXP.test(value);
+
+    if (valid) {
+      setState('VALID');
+    } else {
+      // TODO - I do not fully trust that I understand what the shape of the `ValidationErrors` should be
+      setState('INVALID', {
+        email: {
+          details: true,
+        },
+      });
+    }
+  };
+}

--- a/packages/platform/src/lib/validators/index.ts
+++ b/packages/platform/src/lib/validators/index.ts
@@ -1,3 +1,4 @@
+export * from './email';
 export * from './equals-to';
 export * from './length';
 export * from './max';


### PR DESCRIPTION
Work in progress, would this be considered for acceptance

Reasoning
- I use the reactive for email validator all the time, and I imagine it is just as popular for many other applications
- General parity with the main Angular form packages (at least reactive forms)
- Tricky pattern that people are not likely to implement themselves. The regex pattern for this validator is crazy, and I pulled it directly from the Angular forms package.

Outstanding work
- Remove the reactive form comparison used for my reference
- Parity with implementation of reactive form `email` validator?
    - Though this library makes its own assumptions on validation among other things, I noticed as I lifted the regex pattern that reactive forms `email` validator explicitly says: [`// don't validate empty values to allow optional controls`](https://github.com/angular/angular/blob/17.3.2/packages/forms/src/validators.ts#L494C1-L496C4)
    - However, other validators in this library, especially `pattern` as a close reference, does validate against `null` and `undefined`. And for the moment, I have made this library's proposed `email` validator do the same.
- Tests?
    - I would be happy to write tests, but am not sure how to. Outstanding question/issue for clarification: https://github.com/timdeschryver/ng-signal-forms/issues/38
    - There is more manual testing and consideration that I can do, provided this feature is something there is interest in accepting
 