### PR TITLE
fix: Corrected maxLength validator error name

### DIFF
--- a/packages/platform/src/lib/validators/max-length.ts
+++ b/packages/platform/src/lib/validators/max-length.ts
@@ -9,7 +9,7 @@ export function maxLength(length: number): ValidatorFn<string | Array<unknown>> 
       setState('VALID');
     } else {
       setState('INVALID', {
-        minLength: {
+        maxLength: {
           details: {
             currentLength: value.length,
             maxLength: length


### PR DESCRIPTION
We were using this at work and noticed that the error message doesn't work for the maxLength validator.

The name of the error is minLength, looks like a simple copy/paste error.

Fix just changes the error name.