### PR TITLE
Add method to check for a validator

### DIFF
--- a/packages/platform/src/lib/form-field.ts
+++ b/packages/platform/src/lib/form-field.ts
@@ -13,6 +13,7 @@ import {
   computeState,
   computeValidateState,
   computeValidators,
+  hasValidator,
   InvalidDetails,
   ValidationErrors,
   ValidationState,
@@ -40,6 +41,7 @@ export type FormField<Value = unknown> = {
   markAsDirty: () => void;
   reset: () => void;
   hasError: (errorKey: string) => boolean;
+  hasValidator: (validator: Validator) => boolean;
   errorMessage: (errorKey: string) => string | undefined,
   registerOnReset: (fn: (value: Value) => void) => void;
 };
@@ -158,6 +160,13 @@ export function createFormField<Value>(
     markAsTouched: () => touchedStateSignal.set('TOUCHED'),
     markAsDirty: () => dirtyStateSignal.set('DIRTY'),
     hasError: (errorKey: string) => !!errorsSignal()[errorKey],
+    hasValidator: (validator: Validator) => {
+      if (finalOptions !== undefined) {
+        return hasValidator(finalOptions.validators, validator);
+      } else {
+        return false;
+      }
+    },
     errorMessage: (errorKey: string) => errorsArraySignal().find(e => e.key === errorKey)?.message,
     registerOnReset: (fn: (value: Value) => void) => (onReset = fn),
     reset: () => {

--- a/packages/platform/src/lib/form-group.ts
+++ b/packages/platform/src/lib/form-group.ts
@@ -13,6 +13,7 @@ import {
   computeState,
   computeValidateState,
   computeValidators,
+  hasValidator,
   InvalidDetails,
   ValidationState,
   Validator,
@@ -27,10 +28,10 @@ import {
 export type FormGroup<Fields extends FormGroupCreatorOrSignal = {}> = {
   __type: 'FormGroup';
   value: Signal<UnwrappedFormGroup<Fields>>;
-  controls: Fields extends WritableSignal<FormGroup<infer G>[]> 
-    ? FormGroupFields<Fields> & WritableSignal<FormGroup<G>[]> 
-    : Fields extends WritableSignal<infer F> 
-    ? FormGroupFields<Fields> & WritableSignal<F> 
+  controls: Fields extends WritableSignal<FormGroup<infer G>[]>
+    ? FormGroupFields<Fields> & WritableSignal<FormGroup<G>[]>
+    : Fields extends WritableSignal<infer F>
+    ? FormGroupFields<Fields> & WritableSignal<F>
     : FormGroupFields<Fields>;
   valid: Signal<boolean>;
   state: Signal<ValidationState>;
@@ -41,6 +42,7 @@ export type FormGroup<Fields extends FormGroupCreatorOrSignal = {}> = {
   errors: Signal<{}>;
   errorsArray: Signal<InvalidDetails[]>;
   hasError: (errorKey: string) => boolean;
+  hasValidator: (validator: Validator) => boolean;
   errorMessage: (errorKey: string) => string | undefined;
   markAllAsTouched: () => void;
   reset: () => void;
@@ -179,6 +181,13 @@ export function createFormGroup<FormFields extends FormGroupCreator>(
       return myErrors.concat(...childErrors);
     }),
     hasError: (errorKey: string) => !!errorsSignal()[errorKey],
+    hasValidator: (validator: Validator) => {
+      if (options !== undefined) {
+        return hasValidator(options.validators, validator);
+      } else {
+        return false;
+      }
+    },
     errorMessage: (errorKey: string) => errorsArraySignal().find(e => e.key === errorKey)?.message,
     dirtyState: dirtyStateSignal,
     dirty: dirtySignal,
@@ -205,7 +214,7 @@ export function createFormGroup<FormFields extends FormGroupCreator>(
         (formFieldsMapOrSignal as WritableSignal<any[]>).set([
           ...initialArrayControls,
         ]);
-        
+
         for (const ctrl of initialArrayControls) {
           ctrl.reset();
         }

--- a/packages/platform/src/lib/validation.ts
+++ b/packages/platform/src/lib/validation.ts
@@ -131,3 +131,7 @@ export function computeState(validateSignal: Signal<ValidateState[]>) {
     return 'VALID';
   });
 }
+
+export function hasValidator(validators: Validator<any>[] | undefined, validator: Validator): boolean {
+  return Array.isArray(validators) ? validators.includes(validator) : validators === validator;
+}


### PR DESCRIPTION
This PR adds methods to both the `FormGroup` and `FormField` to check if a specific `Validator` exists. The implementation is inspired by the same methods of the Angular `FormControl` (<https://github.com/angular/angular/blob/c5ce302e0b0667aa7522f80a741241a116abf168/packages/forms/src/validators.ts#L740>).