### PR TITLE
Add method to mark FormField and FormGroup as PRISTINE

### DIFF
--- a/packages/platform/src/lib/form-field.ts
+++ b/packages/platform/src/lib/form-field.ts
@@ -38,6 +38,7 @@ export type FormField<Value = unknown> = {
   readOnly: Signal<boolean>;
   markAsTouched: () => void;
   markAsDirty: () => void;
+  markAsPristine: () => void;
   reset: () => void;
   hasError: (errorKey: string) => boolean;
   errorMessage: (errorKey: string) => string | undefined,
@@ -157,6 +158,7 @@ export function createFormField<Value>(
     readOnly: readOnlySignal,
     markAsTouched: () => touchedStateSignal.set('TOUCHED'),
     markAsDirty: () => dirtyStateSignal.set('DIRTY'),
+    markAsPristine: () => dirtyStateSignal.set('PRISTINE'),
     hasError: (errorKey: string) => !!errorsSignal()[errorKey],
     errorMessage: (errorKey: string) => errorsArraySignal().find(e => e.key === errorKey)?.message,
     registerOnReset: (fn: (value: Value) => void) => (onReset = fn),

--- a/packages/platform/src/lib/form-group.ts
+++ b/packages/platform/src/lib/form-group.ts
@@ -43,7 +43,7 @@ export type FormGroup<Fields extends FormGroupCreatorOrSignal = {}> = {
   hasError: (errorKey: string) => boolean;
   errorMessage: (errorKey: string) => string | undefined;
   markAllAsTouched: () => void;
-  markAsPristine: () => void;
+  markAllAsPristine: () => void;
   reset: () => void;
 };
 
@@ -196,14 +196,16 @@ export function createFormGroup<FormFields extends FormGroupCreator>(
       }
       Object.values(fg).forEach((f) => markFormControlAsTouched(f));
     },
-    markAsPristine: () => {
+    markAllAsPristine: () => {
       const fg = isSignal(formFieldsMapOrSignal)
         ? formFieldsMapOrSignal()
         : formFieldsMapOrSignal;
 
-      Object.values(fg).forEach((f) => {
-        f.markAsPristine();
-      });
+      if (Array.isArray(fg)) {
+        fg.forEach((f) => f.markAsPristine());
+        return;
+      }
+      Object.values(fg).forEach((f) => f.markAsPristine());
     },
     reset: () => {
       const fg = isSignal(formFieldsMapOrSignal)

--- a/packages/platform/src/lib/form-group.ts
+++ b/packages/platform/src/lib/form-group.ts
@@ -27,10 +27,10 @@ import {
 export type FormGroup<Fields extends FormGroupCreatorOrSignal = {}> = {
   __type: 'FormGroup';
   value: Signal<UnwrappedFormGroup<Fields>>;
-  controls: Fields extends WritableSignal<FormGroup<infer G>[]> 
-    ? FormGroupFields<Fields> & WritableSignal<FormGroup<G>[]> 
-    : Fields extends WritableSignal<infer F> 
-    ? FormGroupFields<Fields> & WritableSignal<F> 
+  controls: Fields extends WritableSignal<FormGroup<infer G>[]>
+    ? FormGroupFields<Fields> & WritableSignal<FormGroup<G>[]>
+    : Fields extends WritableSignal<infer F>
+    ? FormGroupFields<Fields> & WritableSignal<F>
     : FormGroupFields<Fields>;
   valid: Signal<boolean>;
   state: Signal<ValidationState>;
@@ -43,6 +43,7 @@ export type FormGroup<Fields extends FormGroupCreatorOrSignal = {}> = {
   hasError: (errorKey: string) => boolean;
   errorMessage: (errorKey: string) => string | undefined;
   markAllAsTouched: () => void;
+  markAsPristine: () => void;
   reset: () => void;
 };
 
@@ -195,6 +196,15 @@ export function createFormGroup<FormFields extends FormGroupCreator>(
       }
       Object.values(fg).forEach((f) => markFormControlAsTouched(f));
     },
+    markAsPristine: () => {
+      const fg = isSignal(formFieldsMapOrSignal)
+        ? formFieldsMapOrSignal()
+        : formFieldsMapOrSignal;
+
+      Object.values(fg).forEach((f) => {
+        f.markAsPristine();
+      });
+    },
     reset: () => {
       const fg = isSignal(formFieldsMapOrSignal)
         ? formFieldsMapOrSignal()
@@ -205,7 +215,7 @@ export function createFormGroup<FormFields extends FormGroupCreator>(
         (formFieldsMapOrSignal as WritableSignal<any[]>).set([
           ...initialArrayControls,
         ]);
-        
+
         for (const ctrl of initialArrayControls) {
           ctrl.reset();
         }


### PR DESCRIPTION
This PR adds methods to both `FormGroup` and `FormField` that marks them as `PRISTINE` to reset the `dirty` flag.